### PR TITLE
Fixing typos in documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
         </tr>
         <tr>
           <th>.opal-framed</th>
-          <td>Declares a default Softened button.</td>
+          <td>Declares a default Framed button.</td>
           <td>
             <a href="#">
               <div class="opal">
@@ -481,7 +481,7 @@
           </td>
         </tr>
         <tr>
-          <th>.opal-outline</th>
+          <th>.opal-awake</th>
           <td>Adds gradient animation on hover.</td>
           <td>
             <a href="#">


### PR DESCRIPTION
Typos fixed for .opal-framed and .opal-awake in http://www.opalescent-css.com/ documentation 